### PR TITLE
Improve benchmark contribution PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,40 @@
 ## Benchmark
 
-<!-- For changes unrelated to benchmark entries, replace this section with a short summary. -->
+<!-- Use this template for benchmark additions and corrections. For unrelated changes, replace it with a short description and relevant validation. -->
 
 - Name:
 - Organization:
 - Official benchmark URL:
-- Categories:
+- Code / paper / dataset URLs (when available):
 
 ### What does it evaluate?
 
-<!-- Briefly describe what the benchmark compares and why it is useful for engineers building voice agents. -->
+<!-- In one or two sentences, describe what is evaluated and why this entry belongs in the directory. For corrections, explain what was inaccurate and the corrected behavior. Note overlap with existing entries when relevant. -->
+
+### Classification and evidence
+
+<!-- Link to owner-published sources supporting these choices. Explain material limitations or uncertainty; use unknown where supported rather than guessing. Public code alone does not establish that the complete evaluation is open. -->
+
+- Categories and architectures:
+- Benchmark type and evaluation method:
+- Openness:
+
+### Validation
+
+<!-- Record results and disclose any failed or skipped checks with a reason. Check boxes only for completed work. -->
+
+- [ ] `npm ci`
+- [ ] `npm run lint`
+- [ ] `npm test`
+- [ ] `npm run build`
 
 ## Checklist
 
 - [ ] Added or updated a JSON entry in `data/benchmarks/` using the schema in CONTRIBUTING.md.
 - [ ] Used a unique lowercase, hyphenated ID and selected all relevant categories.
+- [ ] Checked the existing catalog to avoid a duplicate entry.
 - [ ] Wrote a neutral description and checked the official source links.
 - [ ] Linked to published materials instead of copying model scores, datasets, or benchmark content.
-- [ ] Ran `npm run lint` and `npm run build` successfully.
+- [ ] Left popularity counts to the automated stats workflow.
 
 <!-- Optional: link a related issue, e.g. Closes #123. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Do not copy model scores, datasets, papers, or private information into the repo
 4. Classify benchmark type, evaluation method, and openness. Use `unknown` rather than guessing where that value is supported.
 5. Check the official website, code, and paper links.
 6. Run `npm ci`, `npm run lint`, `npm test`, and `npm run build`.
-7. Open a pull request describing the entry or correction, with a link to any related issue.
+7. Open a pull request using the [benchmark PR template](.github/pull_request_template.md). Describe what it evaluates and why it belongs, cite owner-published evidence for the classifications, and report validation results and any uncertainty. Link any related issue.
 
 Create a JSON file in `data/benchmarks/` using this template:
 


### PR DESCRIPTION
The benchmark PR template omitted the required test run and did not ask contributors to support classification choices. It now asks for source evidence, scope, openness limitations, duplicate checks, and the full validation checklist. CONTRIBUTING.md links to the template and explains what reviewers need.

Validation: `npm ci`, `npm run lint`, `npm test` (7 passing), `npm run build`, and `git diff --check` all passed.
