### PR TITLE
Add MIVAS voice agent benchmark

### DIFF
--- a/data/benchmarks/mivas-bench.json
+++ b/data/benchmarks/mivas-bench.json
@@ -1,0 +1,13 @@
+{
+  "id": "mivas-bench",
+  "name": "MIVAS Bench",
+  "organization": "Bluejay Labs",
+  "description": "Evaluates voice agents on multi-industry workflows through deterministic checks of tool use, specialist handoffs, and final database state.",
+  "categories": ["s2s", "voice-agents"],
+  "benchmarkType": "benchmark",
+  "evaluationMethod": "deterministic",
+  "openness": "partially-open",
+  "websiteUrl": "https://research.getbluejay.ai/benchmarks/mivas/leaderboard",
+  "codeUrl": "https://github.com/bluejay-ai-dev/mivas-bench",
+  "architectures": ["cascaded", "speech-to-speech"]
+}


### PR DESCRIPTION
## Benchmark

- Name: MIVAS Bench
- Organization: Bluejay Labs
- Official benchmark URL: https://research.getbluejay.ai/benchmarks/mivas/leaderboard
- Code / paper / dataset URLs: [Repository](https://github.com/bluejay-ai-dev/mivas-bench), [dataset](https://huggingface.co/datasets/bluejay-labs/mivas-bench). No separately verified paper URL is added.

### What does it evaluate?

Adds MIVAS to the Speech-to-Speech and Voice Agents catalog: it evaluates voice agents on healthcare, legal, and customer-support workflows using checks of tool use, specialist handoffs, and final database state. It complements the existing τ-Voice and VoiceAgentBench entries with its explicit focus on specialist routing and conjunctive outcome verification.

### Classification and evidence

- Categories and architectures: `s2s`, `voice-agents`; `cascaded`, `speech-to-speech`. The [repository methodology](https://github.com/bluejay-ai-dev/mivas-bench#methodology) evaluates native speech-to-speech systems within multi-agent runtimes, with a cascaded baseline. Scores describe the composed model and harness, rather than isolated model capability.
- Benchmark type and evaluation method: `benchmark`, `deterministic`. The [verification specification](https://github.com/bluejay-ai-dev/mivas-bench#conjunctive-deterministic-verification) requires applicable tool, handoff, and database-state checks to pass. Audio quality and latency are diagnostic evidence rather than the task-correctness criterion.
- Openness: `partially-open`. Prompts, tasks, harnesses, and verifiers are public, but the published evaluation uses Bluejay Digital Humans. The [caller setup script](https://github.com/bluejay-ai-dev/mivas-bench/blob/main/scripts/tasks_to_digital_humans.py) builds payloads for Bluejay's API. An independently runnable release of the exact caller simulator has not been verified, so the entry does not claim the complete evaluation is open.

### Validation

- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm test` — 7 tests passed
- [x] `npm run build`

The official leaderboard returned HTTP 200; the repository and dataset were inspected. `git diff --check` passed.

## Checklist

- [x] Added or updated a JSON entry in `data/benchmarks/` using the schema in CONTRIBUTING.md.
- [x] Used a unique lowercase, hyphenated ID and selected all relevant categories.
- [x] Checked the existing catalog to avoid a duplicate entry.
- [x] Wrote a neutral description and checked the official source links.
- [x] Linked to published materials instead of copying model scores, datasets, or benchmark content.
- [x] Left popularity counts to the automated stats workflow.

Depends on #11. This PR targets the template branch so its diff contains only the benchmark entry. After #11 merges, retarget this PR to `main`.
