### PR TITLE
Add MIVAS voice agent benchmark

### DIFF
--- a/data/benchmarks/mivas-bench.json
+++ b/data/benchmarks/mivas-bench.json
@@ -1,0 +1,13 @@
+{
+  "id": "mivas-bench",
+  "name": "MIVAS Bench",
+  "organization": "Bluejay Labs",
+  "description": "Evaluates voice agents on multi-industry workflows through deterministic checks of tool use, specialist handoffs, and final database state.",
+  "categories": ["s2s", "voice-agents"],
+  "benchmarkType": "benchmark",
+  "evaluationMethod": "deterministic",
+  "openness": "partially-open",
+  "websiteUrl": "https://research.getbluejay.ai/benchmarks/mivas/leaderboard",
+  "codeUrl": "https://github.com/bluejay-ai-dev/mivas-bench",
+  "architectures": ["cascaded", "speech-to-speech"]
+}


### PR DESCRIPTION
## Benchmark

- Name: MIVAS Bench
- Organization: Bluejay Labs
- Official benchmark URL: https://research.getbluejay.ai/benchmarks/mivas/leaderboard
- Categories: Speech-to-Speech, Voice Agents

### What does it evaluate?

Evaluates voice agents on healthcare, legal, and customer-support workflows through deterministic checks of tool use, specialist handoffs, and final database state. It covers native speech-to-speech systems and a cascaded baseline.

The [code and methodology](https://github.com/bluejay-ai-dev/mivas-bench) and [dataset](https://huggingface.co/datasets/bluejay-labs/mivas-bench) are public. Classified as partially open because the [caller setup](https://github.com/bluejay-ai-dev/mivas-bench/blob/main/scripts/tasks_to_digital_humans.py) uses Bluejay's API; an independently runnable release of the exact simulator has not been verified.

## Checklist

- [x] Added or updated a JSON entry in `data/benchmarks/` using the schema in CONTRIBUTING.md.
- [x] Used a unique lowercase, hyphenated ID and selected all relevant categories.
- [x] Wrote a neutral description and checked the official source links.
- [x] Linked to published materials instead of copying model scores, datasets, or benchmark content.
- [x] Ran `npm run lint` and `npm run build` successfully.

Also ran `npm ci`, `npm test` (7 passing), and `git diff --check` successfully.
