### PR TITLE
Add Speko Benchmarks

### DIFF
--- a/data/benchmarks/speko-benchmarks.json
+++ b/data/benchmarks/speko-benchmarks.json
@@ -1,0 +1,12 @@
+{
+  "id": "speko-benchmarks",
+  "name": "Speko Benchmarks",
+  "organization": "Speko",
+  "description": "Measures STT, TTS, LLM, turn-taking and speech-to-speech providers on latency and accuracy from a single production voice gateway, and ranks assembled agent stacks.",
+  "categories": ["stt", "tts", "turn-taking", "llm", "s2s", "voice-agents"],
+  "benchmarkType": "leaderboard",
+  "evaluationMethod": "mixed",
+  "openness": "partially-open",
+  "websiteUrl": "https://benchmarks.speko.ai",
+  "architectures": ["cascaded", "speech-to-speech", "hybrid"]
+}


### PR DESCRIPTION
Adds an entry for [Speko Benchmarks](https://benchmarks.speko.ai), a hosted leaderboard for voice-agent components.

**What it compares:** commercial and open-weights STT, TTS, LLM, turn-taking and speech-to-speech models, measured on accuracy and production latency. It also ranks assembled agent stacks (STT + LLM + TTS combinations), and publishes per-model detail pages plus per-board methodology write-ups at `/blog`.

**Classification rationale:**
- `categories`: all six — boards exist at `/stt`, `/tts`, `/llm`, `/s2s`, `/turntaking`, and `/stacks` for complete systems.
- `benchmarkType: leaderboard` — continuously updated ranked boards rather than a fixed released suite.
- `evaluationMethod: mixed` — automatic accuracy metrics (WER/CER), deterministic latency measurement, and human preference listening tests.
- `openness: partially-open` — results, per-model pages and methodology are public; the harness and gateway are not.
- `architectures`: cascaded, speech-to-speech, and hybrid all appear on the stacks board.
- No `codeUrl` or `paperUrl`: the harness is not published, and methodology lives in the site’s own write-ups rather than a paper.

Disclosure: I work at Speko. Happy to adjust any field, or to drop the entry if a self-submitted leaderboard is out of scope.

**Checks:** `bun install`, `bun run lint`, `bun run test` (7/7 pass), `bun run build` all clean; the new entry renders in the built bundle.